### PR TITLE
Repair release workflow version parsing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,7 +60,7 @@ jobs:
         id: version
         run: |
           # Get current version from mix.exs
-          CURRENT_VERSION=$(grep 'version:' mix.exs | head -1 | sed 's/.*version: "\(.*\)".*/\1/')
+          CURRENT_VERSION=$(grep '@version ' mix.exs | head -1 | sed 's/.*@version "\(.*\)".*/\1/')
           echo "Current version: $CURRENT_VERSION"
           
           # Remove any existing pre-release suffix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 env:
   ELIXIR_VERSION: "1.17.3"
   OTP_VERSION: "27.0"
@@ -58,7 +61,7 @@ jobs:
       
       - name: Verify version match
         run: |
-          MIX_VERSION=$(grep 'version:' mix.exs | head -1 | sed 's/.*version: "\(.*\)".*/\1/')
+          MIX_VERSION=$(grep '@version ' mix.exs | head -1 | sed 's/.*@version "\(.*\)".*/\1/')
           if [ "$MIX_VERSION" != "${{ steps.version.outputs.version }}" ]; then
             echo "Version mismatch!"
             echo "Tag/Input version: ${{ steps.version.outputs.version }}"
@@ -299,7 +302,7 @@ jobs:
           NEXT_VERSION="$major.$minor.$((patch + 1))-dev"
           
           # Update mix.exs with development version
-          sed -i "s/version: \"$CURRENT_VERSION\"/version: \"$NEXT_VERSION\"/" mix.exs
+          sed -i "s/@version \"$CURRENT_VERSION\"/@version \"$NEXT_VERSION\"/" mix.exs
           
           # Commit the change
           git add mix.exs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add `ash_phoenix_translations` to your dependencies:
 ```elixir
 def deps do
   [
-    {:ash_phoenix_translations, "~> 1.0.0"}
+    {:ash_phoenix_translations, "~> 1.0.1"}
   ]
 end
 ```


### PR DESCRIPTION
## What

- The release workflow's version-match check and its next-dev-version `sed` both parsed `version:` from mix.exs, which matches the `version: @version,` line instead of the `@version "x.y.z"` attribute. Both now parse the `@version` line. Same fix in prerelease.yml.
- README.md still said 1.0.0, which failed the workflow's `mix ash_phoenix_translations.version check` step; synced to 1.0.1 via the task's own `sync` command.
- Added an explicit `permissions: contents: write` block for the GitHub-release and post-release push steps.

## Why

The v1.0.1 tag push triggered the release workflow for the first time ever and it failed at the Validate Release job, so nothing was published to Hex. Every failure is a latent bug that predates the release: the workflow was written against an inline `version:` string that mix.exs has never used.

## Testing

- `grep '@version ' mix.exs | head -1 | sed 's/.*@version "\(.*\)".*/\1/'` prints `1.0.1` locally.
- `mix ash_phoenix_translations.version check` passes after the README sync.
- `mix docs` builds cleanly (the Build Documentation job's only real dependency).

## Risks & out-of-scope

- The post-release job auto-bumps main to `x.y.z+1-dev` after publishing; that behavior is kept as designed, just repaired.
- The Hex publish step itself still depends on the stored HEX_API_KEY being valid; that's only provable by running the workflow.

After merge: delete and re-push the v1.0.1 tag pointing at the new main tip so the tag-triggered run uses the fixed workflow.