### PR TITLE
Write release archive outside the tree being archived

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,12 +190,16 @@ jobs:
       
       - name: Create release archive
         run: |
-          tar czf ash_phoenix_translations-${{ needs.validate.outputs.version }}.tar.gz \
+          # Write to RUNNER_TEMP first: creating the archive inside the
+          # directory being archived makes tar exit 1 (file changed as we
+          # read it).
+          tar czf "$RUNNER_TEMP/ash_phoenix_translations-${{ needs.validate.outputs.version }}.tar.gz" \
             --exclude=.git \
             --exclude=_build \
             --exclude=deps \
             --exclude=.github \
             .
+          mv "$RUNNER_TEMP/ash_phoenix_translations-${{ needs.validate.outputs.version }}.tar.gz" .
       
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## What

The release workflow's archive step ran `tar czf <output> .` with the output file inside the directory being archived. GNU tar notices the directory changing under it and exits 1 ("file changed as we read it"), which failed the Create GitHub Release job on the v1.0.1 run. The archive is now written to `$RUNNER_TEMP` and moved back so the softprops file reference keeps working.

## Why

Third latent bug chain in the never-before-exercised release pipeline; this was the only failure in the last run (validate, tests, and docs all passed).

## Testing

The exit-1 behavior is GNU-tar-specific, so it isn't reproducible on macOS (bsdtar warns "Can't add archive to itself" but exits 0). Evidence is the run log itself: run 28903921335 shows `tar: .: file changed as we read it` followed by exit code 1. Writing the archive outside the tree removes the trigger in both implementations.

## Risks & out-of-scope

Remaining unexercised steps are the softprops release action itself and the two Hex publish jobs; nothing verifiable locally is left.